### PR TITLE
Fix #1: The "is installed" test is unreliable

### DIFF
--- a/inc/plugins/PrefixFilter.php
+++ b/inc/plugins/PrefixFilter.php
@@ -139,7 +139,7 @@ function PrefixFilter_is_installed()
 {
 	global $db;
 
-	$query = $db->simple_select('themestylesheets', 'sid', "name='PrefixFilter.css'");
+	$query = $db->simple_select('settinggroups', 'gid', "name='PrefixFilter'");
 	return ($db->num_rows($query) > 0);
 }
 


### PR DESCRIPTION
Check for the existence of the plugin's settings group rather than its stylesheet. This is reliable because the plugin's settings are not mistakenly deleted by the bug noted in #1 as the Master stylesheet is.

Resolves #1